### PR TITLE
fix: add button in home screen navigation alert to open swap on iOS

### DIFF
--- a/src/components/templates/AccountActions/components/Swap.tsx
+++ b/src/components/templates/AccountActions/components/Swap.tsx
@@ -37,7 +37,7 @@ export const Swap = ({ disabled }: SwapActionProps) => {
         disclaimerModalRef?.current?.show({
           title: t('browser.disclaimer.header'),
           subTitle: t('browser.disclaimer.description'),
-          buttonsLabels: [t('button.processed')],
+          buttonsLabels: [t('button.cancel'), t('button.processed')],
           onApprove: () => navigateToAstra(swapItem.uri)
         });
       }


### PR DESCRIPTION
add button to navigation alert from home scree to swap on ios platforms